### PR TITLE
Feature/untp validator dcc b

### DIFF
--- a/backend/app/models/untp_manual.py
+++ b/backend/app/models/untp_manual.py
@@ -1,0 +1,240 @@
+"""Loose Pydantic shapes for DCC issuance in the UNTP plugin (not JSON-Schema-derived).
+
+For schema-aligned UNTP v0.7.0 models, see :mod:`app.models.untp.v0_7_0`.
+"""
+
+from typing import List, Optional, Dict, Any
+from enum import Enum
+from pydantic import BaseModel, Field, AnyUrl
+# from .codes import EncryptionMethod, HashMethod
+
+
+class BaseModel(BaseModel):
+    type: List[str] = None
+    id: str = None
+    name: str = None
+    description: str = None
+
+    def model_dump(self, **kwargs) -> Dict[str, Any]:
+        return super().model_dump(by_alias=True, exclude_none=True, **kwargs)
+
+
+class IdentifierScheme(BaseModel):
+    type: List[str] = ["IdentifierScheme"]
+
+
+class Identifier(BaseModel):
+    type: List[str] = ["Identifier"]
+
+    registeredId: str
+    idScheme: IdentifierScheme
+
+
+class Party(BaseModel):
+    type: List[str] = ["Party"]
+
+    registeredId: Optional[str] = None
+    idScheme: Optional[IdentifierScheme] = None
+    registrationCountry: Optional[IdentifierScheme] = None
+    organisationWebsite: Optional[IdentifierScheme] = None
+    industryCategory: Optional[IdentifierScheme] = None
+    otherIdentifier: Optional[Identifier] = None
+
+
+class BinaryFile(BaseModel):
+    type: List[str] = ["BinaryFile"]
+
+    fileName: str
+    fileType: str  # https://mimetype.io/all-types
+    file: str  # Base64
+
+
+class Link(BaseModel):
+    type: List[str] = ["Link"]
+
+    linkURL: AnyUrl
+    linkName: str
+    linkType: str  # drawn from a controlled vocabulary
+
+
+class SecureLink(BaseModel):
+    type: List[str] = ["SecureLink"]
+
+    linkUrl: AnyUrl
+    linkName: str
+    linkType: str
+    hashDigest: str
+    # hashMethod: HashMethod
+    # encryptionMethod: EncryptionMethod
+
+
+class Measure(BaseModel):
+    type: List[str] = ["Measure"]
+
+    value: float
+    unit: str = Field(
+        max_length=3
+    )  # from https://vocabulary.uncefact.org/UnitMeasureCode
+
+
+class Endorsement(BaseModel):
+    type: str = "Endorsement"
+
+    id: AnyUrl
+    name: str
+    trustmark: Optional[BinaryFile] = None
+    issuingAuthority: Party
+    accreditationCertification: Optional[Link] = None
+
+
+class Standard(BaseModel):
+    type: str = "Standard"
+
+    id: AnyUrl
+    name: str
+    issuingParty: Party
+    issueDate: str  # iso8601 datetime string
+
+
+class Regulation(BaseModel):
+    type: List[str] = ["Regulation"]
+
+    id: str = None
+    name: str = None
+    jurisdictionCountry: (
+        str  # countryCode from https://vocabulary.uncefact.org/CountryId
+    )
+    administeredBy: Party
+    effectiveDate: str = None  # iso8601 datetime string
+
+
+class Metric(BaseModel):
+    type: str = "Metric"
+
+    metricName: str
+    metricValue: Measure
+    accuracy: float
+
+
+class Criterion(BaseModel):
+    type: str = "Criterion"
+
+    id: AnyUrl
+    name: str
+    thresholdValues: Metric
+
+
+class Facility(BaseModel):
+    type: List[str] = ["Facility"]
+
+    # this looks wrongs
+    id: AnyUrl  # The globally unique ID of the Party as a resolvable URL according to ISO 18975.
+    name: str
+    registeredId: Optional[str] = None
+    idScheme: Optional[IdentifierScheme] = None
+    IDverifiedByCAB: bool
+
+
+class Product(BaseModel):
+    type: List[str] = ["Product"]
+
+    id: AnyUrl = None  # The globally unique ID of the Party as a resolvable URL according to ISO 18975.
+    name: str = None
+    registeredId: Optional[str] = None
+    idScheme: Optional[IdentifierScheme] = None
+    IDverifiedByCAB: bool = None
+
+
+class ConformityAssessment(BaseModel):
+    type: List[str] = ["ConformityAssessment"]
+
+    id: str = None
+    referenceStandard: Optional[Standard] = None  # defines the specification
+    referenceRegulation: Optional[Regulation] = None  # defines the regulation
+    assessmentCriterion: Optional[Criterion] = None  # defines the criteria
+    declaredValues: Optional[List[Metric]] = None
+
+    conformityTopic: str = None
+
+    assessedProduct: Optional[List[Product]] = []
+    assessedFacility: Optional[List[Facility]] = []
+
+
+class ConformityAssessmentScheme(BaseModel):
+    type: str = "ConformityAssessmentScheme"
+
+    id: str
+    name: str
+    issuingParty: Optional[Party] = None
+    issueDate: Optional[str] = None  # ISO8601 datetime string
+    trustmark: Optional[BinaryFile] = None
+
+
+class ConformityAttestation(BaseModel):
+    type: List[str] = ["ConformityAttestation"]
+    id: str = None
+    assessorLevel: Optional[str] = None
+    assessmentLevel: str = None
+    attestationType: str = None
+    issuedToParty: Party = None
+    authorisations: Optional[Endorsement] = None
+    conformityCertificate: Optional[SecureLink] = None
+    auditableEvidence: Optional[SecureLink] = None
+    scope: ConformityAssessmentScheme = None
+    assessment: List[ConformityAssessment] = None
+
+
+class AssessorLevelCode(str, Enum):
+    Self = "Self"
+    Commercial = "Commercial"
+    Buyer = "Buyer"
+    Membership = "Membership"
+    Unspecified = "Unspecified"
+    ThirdParty = "3rdParty"
+
+
+class AssessmentLevelCode(str, Enum):
+    GovtApproval = "GovtApproval"
+    GlobalMLA = "GlobalMLA"
+    Accredited = "Accredited"
+    Verified = "Verified"
+    Validated = "Validated"
+    Unspecified = "Unspecified"
+
+
+class AttestationType(str, Enum):
+    Certification = "Certification"
+    Declaration = "Declaration"
+    Inspection = "Inspection"
+    Testing = "Testing"
+    Verification = "Verification"
+    Validation = "Validation"
+    Calibration = "Calibration"
+
+
+class HashMethod(str, Enum):
+    SHA256 = "SHA-256"
+    SHA1 = "SHA-1"
+
+
+class EncryptionMethod(str, Enum):
+    NONE = "None"
+    AES = "AES"
+
+
+class ConformityTopicCode(str, Enum):
+    Environment_Energy = "Environment.Energy"
+    Environment_Emissions = "Environment.Emissions"
+    Environment_Water = "Environment.Water"
+    Environment_Waste = "Environment.Waste"
+    Environment_Deforestation = "Environment.Deforestation"
+    Environment_Biodiversity = "Environment.Biodiversity"
+    Cirularity_Content = "Circularity.Content"
+    Cirularity_Design = "Circularity.Design"
+    Social_Labour = "Social.Labour"
+    Social_Rights = "Social.Rights"
+    Social_Safety = "Social.Safety"
+    Social_Community = "Social.Community"
+    Governance_Ethics = "Governance.Ethics"
+    Governance_Compliance = "Governance.Compliance"
+    Governance_Transparency = "Governance.Transparency"

--- a/backend/app/plugins/untp.py
+++ b/backend/app/plugins/untp.py
@@ -1,4 +1,4 @@
-from app.models.untp import Product, Facility, ConformityAssessment, Regulation, ConformityAttestation, Party, IdentifierScheme, ConformityAssessmentScheme
+from app.models.untp_manual import Product, Facility, ConformityAssessment, Regulation, ConformityAttestation, Party, IdentifierScheme, ConformityAssessmentScheme
 from app.plugins.soup import Soup
 from untp.releases import DEFAULT_DCC_CONTEXT_URL
 

--- a/backend/app/validators/__init__.py
+++ b/backend/app/validators/__init__.py
@@ -1,0 +1,29 @@
+"""Application validators (e.g. incoming UNTP payloads)."""
+
+from app.validators.untp import (
+    UntpArtefactKind,
+    UntpValidatedDocument,
+    UntpValidationError,
+    UntpValidationRun,
+    detect_untp_artefact_kind,
+    first_failed_validation_check,
+    validate_untp_document,
+    validate_untp_document_with_checks,
+    validate_untp_json_ld,
+    validate_untp_json_schema,
+    validate_untp_pydantic,
+)
+
+__all__ = [
+    "UntpArtefactKind",
+    "UntpValidatedDocument",
+    "UntpValidationError",
+    "UntpValidationRun",
+    "detect_untp_artefact_kind",
+    "first_failed_validation_check",
+    "validate_untp_document",
+    "validate_untp_document_with_checks",
+    "validate_untp_json_ld",
+    "validate_untp_json_schema",
+    "validate_untp_pydantic",
+]

--- a/backend/app/validators/untp.py
+++ b/backend/app/validators/untp.py
@@ -1,0 +1,329 @@
+"""
+Validate UNTP JSON artefacts: JSON Schema (draft 2020-12), JSON-LD → RDF, and Pydantic models.
+
+Use this module for API payloads. Bundled schemas and contexts live
+under the ``untp`` package; JSON-LD resolution is offline via :mod:`untp.jsonld_loader`.
+
+Typical use (e.g. FastAPI body already parsed to a ``dict``)::
+
+    from app.validators.untp import validate_untp_document
+
+    result = validate_untp_document(body)
+    credential = result.model  # v0.7.0 Pydantic instance
+    rdf = result.rdf_nquads  # JSON-LD interpreted as RDF (N-Quads)
+
+Use :func:`validate_untp_document_with_checks` when you need per-check payloads (same shape as
+HTTP ``validation_checks``).
+
+JSON-LD uses rdflib with a bundled-context-only hook: ``@context`` URLs must be in
+:data:`untp.releases.CONTEXT_BUNDLE` (inlined from ``untp/bundled/``); other http(s)
+context URLs raise :exc:`untp.jsonld_loader.UntpJsonLdRemoteContextError` (wrapped as
+:exc:`UntpValidationError`).
+"""
+
+from __future__ import annotations
+
+import json
+import untp as _untp_package
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import ValidationError as JsonSchemaValidationError
+from pydantic import BaseModel, ValidationError as PydanticValidationError
+from rdflib.plugins.shared.jsonld.errors import JSONLDException
+
+from untp.jsonld_loader import UntpJsonLdRemoteContextError, jsonld_to_rdf_nquads
+from untp.releases import SCHEMA_BUNDLE, bundled_context_digests_for_document
+
+_BUNDLED_ROOT = Path(_untp_package.__file__).resolve().parent / "bundled"
+
+
+class UntpArtefactKind(StrEnum):
+    DCC_CREDENTIAL = "dcc_credential"
+    DCC_ATTESTATION = "dcc_attestation"
+
+
+_SCHEMA_URL: dict[UntpArtefactKind, str] = {
+    UntpArtefactKind.DCC_CREDENTIAL: (
+        "https://untp.unece.org/artefacts/schema/v0.7.0/dcc/ConformityCredential.json"
+    ),
+    UntpArtefactKind.DCC_ATTESTATION: (
+        "https://untp.unece.org/artefacts/schema/v0.7.0/dcc/ConformityAttestation.json"
+    ),
+}
+
+_validators: dict[UntpArtefactKind, Draft202012Validator] = {}
+
+# Order for reporting / finding the first failed check in :attr:`UntpValidationRun.checks`
+# (serialized as HTTP ``validation_checks``).
+VALIDATION_CHECK_KEYS: tuple[str, ...] = (
+    "document_root",
+    "json_schema",
+    "json_ld",
+    "data_model",
+)
+
+
+def _subject_schema_kind_for_credential(
+    envelope_kind: UntpArtefactKind,
+) -> UntpArtefactKind | None:
+    """When validating a VC envelope, return the kind for ``credentialSubject``'s schema."""
+    if envelope_kind is UntpArtefactKind.DCC_CREDENTIAL:
+        return UntpArtefactKind.DCC_ATTESTATION
+    return None
+
+
+class UntpValidationError(ValueError):
+    """Raised when UNTP validation fails (detection, JSON Schema, JSON-LD, or Pydantic)."""
+
+
+@dataclass(frozen=True)
+class UntpValidatedDocument:
+    """Outcome of a full UNTP validation pipeline."""
+
+    raw: dict[str, Any]
+    rdf_nquads: str
+    model: BaseModel
+    kind: UntpArtefactKind
+
+
+@dataclass(frozen=True)
+class UntpValidationRun:
+    """Result of :func:`validate_untp_document_with_checks`."""
+
+    success: bool
+    #: Check id → payload (same keys as HTTP ``validation_checks``). ``json_schema`` is a list of
+    #: ``{schema_id, pass, error?}``; other entries are dicts.
+    checks: dict[str, Any]
+    document: UntpValidatedDocument | None
+    #: First failing :exc:`UntpValidationError` (preserves ``__cause__`` for :func:`validate_untp_document`).
+    raising: UntpValidationError | None = None
+
+
+def first_failed_validation_check(
+    checks: Mapping[str, Any],
+) -> tuple[str, dict[str, Any]] | None:
+    """Return ``(check_id, failing_fragment)`` for the first failing check."""
+    for key in VALIDATION_CHECK_KEYS:
+        if key not in checks:
+            continue
+        payload = checks[key]
+        if key == "json_schema" and isinstance(payload, list):
+            for item in payload:
+                if isinstance(item, dict) and not item.get("pass", False):
+                    return key, item
+            continue
+        if isinstance(payload, dict) and not payload.get("pass", False):
+            return key, payload
+    return None
+
+
+def detect_untp_artefact_kind(data: Mapping[str, Any]) -> UntpArtefactKind:
+    """Infer :class:`UntpArtefactKind` from the ``type`` property."""
+    t = data.get("type")
+    if t is None:
+        raise UntpValidationError('document is missing required "type" property')
+    types = [t] if isinstance(t, str) else list(t)
+    if "DigitalConformityCredential" in types:
+        return UntpArtefactKind.DCC_CREDENTIAL
+    if "VerifiableCredential" in types:
+        raise UntpValidationError(
+            f"unsupported VerifiableCredential subtype in type={types!r}"
+        )
+    if "ConformityAttestation" in types:
+        return UntpArtefactKind.DCC_ATTESTATION
+    raise UntpValidationError(f"unknown UNTP document type={types!r}")
+
+
+def _schema_path_for_kind(kind: UntpArtefactKind) -> Path:
+    url = _SCHEMA_URL[kind]
+    try:
+        rel = SCHEMA_BUNDLE[url]["path"]
+    except KeyError as e:
+        raise UntpValidationError(f"no bundled schema for {kind}") from e
+    return _BUNDLED_ROOT / rel
+
+
+def _validator_for_kind(kind: UntpArtefactKind) -> Draft202012Validator:
+    if kind not in _validators:
+        path = _schema_path_for_kind(kind)
+        schema = json.loads(path.read_text(encoding="utf-8"))
+        _validators[kind] = Draft202012Validator(schema)
+    return _validators[kind]
+
+
+def validate_untp_json_schema(data: Mapping[str, Any], kind: UntpArtefactKind) -> None:
+    """Validate ``data`` against the bundled UNTP JSON Schema for ``kind``."""
+    try:
+        _validator_for_kind(kind).validate(data)
+    except JsonSchemaValidationError as e:
+        raise UntpValidationError("JSON Schema validation failed") from e
+
+
+def validate_untp_json_ld(data: Mapping[str, Any]) -> str:
+    """
+    Interpret JSON-LD as RDF and return **N-Quads**.
+
+    Remote ``@context`` resolution uses only :data:`untp.releases.CONTEXT_BUNDLE`;
+    unbundled http(s) context URLs are not fetched.
+    """
+    if not isinstance(data, dict):
+        raise UntpValidationError("JSON-LD document must be a JSON object (dict)")
+    try:
+        return jsonld_to_rdf_nquads(data)
+    except (JSONLDException, ValueError, OSError, UntpJsonLdRemoteContextError) as e:
+        raise UntpValidationError("JSON-LD processing failed") from e
+
+
+def _pydantic_model_for_kind(kind: UntpArtefactKind) -> type[BaseModel]:
+    if kind is UntpArtefactKind.DCC_CREDENTIAL:
+        from app.models.untp.v0_7_0.dcc.digital_conformity_credential import (
+            DigitalConformityCredential,
+        )
+
+        return DigitalConformityCredential
+    if kind is UntpArtefactKind.DCC_ATTESTATION:
+        from app.models.untp.v0_7_0.dcc.conformity_attestation import (
+            ConformityAttestation,
+        )
+
+        return ConformityAttestation
+    raise UntpValidationError(f"no Pydantic model mapped for {kind!r}")
+
+
+def validate_untp_pydantic(data: Mapping[str, Any], kind: UntpArtefactKind) -> BaseModel:
+    """Parse ``data`` into the v0.7.0 Pydantic model for ``kind``."""
+    model_cls = _pydantic_model_for_kind(kind)
+    try:
+        return model_cls.model_validate(data)
+    except PydanticValidationError as e:
+        raise UntpValidationError("Pydantic model validation failed") from e
+
+
+def validate_untp_document_with_checks(
+    data: Mapping[str, Any],
+    *,
+    kind: UntpArtefactKind | None = None,
+) -> UntpValidationRun:
+    """
+    Run the same checks as :func:`validate_untp_document`, recording each check.
+
+    For ``DigitalConformityCredential`` envelopes, also validates ``credentialSubject`` against ``ConformityAttestation`` JSON Schema.
+
+    Stops at the first failing check; later checks are not run (not listed).
+    """
+    out: dict[str, Any] = {}
+
+    if not isinstance(data, dict):
+        out["document_root"] = {
+            "pass": False,
+            "error": "document must be a JSON object (dict)",
+        }
+        return UntpValidationRun(
+            False,
+            out,
+            None,
+            UntpValidationError("document must be a JSON object (dict)"),
+        )
+
+    raw = dict(data)
+
+    try:
+        k = kind or detect_untp_artefact_kind(raw)
+    except UntpValidationError as e:
+        return UntpValidationRun(False, out, None, e)
+
+    js: list[dict[str, Any]] = []
+    envelope_schema_id = _SCHEMA_URL[k]
+    try:
+        validate_untp_json_schema(raw, k)
+        js.append({"schema_id": envelope_schema_id, "pass": True})
+    except UntpValidationError as e:
+        js.append(
+            {
+                "schema_id": envelope_schema_id,
+                "pass": False,
+                "error": str(e),
+            }
+        )
+        out["json_schema"] = js
+        return UntpValidationRun(False, out, None, e)
+
+    sub_kind = _subject_schema_kind_for_credential(k)
+    if sub_kind is not None:
+        subject = raw.get("credentialSubject")
+        subject_schema_id = _SCHEMA_URL[sub_kind]
+        if not isinstance(subject, Mapping):
+            err = UntpValidationError(
+                'credential must contain a JSON object "credentialSubject"'
+            )
+            js.append(
+                {
+                    "schema_id": subject_schema_id,
+                    "pass": False,
+                    "error": str(err),
+                }
+            )
+            out["json_schema"] = js
+            return UntpValidationRun(False, out, None, err)
+        try:
+            validate_untp_json_schema(subject, sub_kind)
+            js.append({"schema_id": subject_schema_id, "pass": True})
+        except UntpValidationError as e:
+            js.append(
+                {
+                    "schema_id": subject_schema_id,
+                    "pass": False,
+                    "error": str(e),
+                }
+            )
+            out["json_schema"] = js
+            return UntpValidationRun(False, out, None, e)
+
+    out["json_schema"] = js
+
+    try:
+        rdf_nquads = validate_untp_json_ld(raw)
+        ctx_digests = bundled_context_digests_for_document(raw)
+        out["json_ld"] = {
+            "pass": True,
+            "rdf_nquads_length": len(rdf_nquads),
+            "context_digests": ctx_digests,
+        }
+    except UntpValidationError as e:
+        out["json_ld"] = {"pass": False, "error": str(e)}
+        return UntpValidationRun(False, out, None, e)
+
+    try:
+        model = validate_untp_pydantic(raw, k)
+        out["data_model"] = {"pass": True, "type": model.__class__.__name__}
+    except UntpValidationError as e:
+        out["data_model"] = {"pass": False, "error": str(e)}
+        return UntpValidationRun(False, out, None, e)
+
+    doc = UntpValidatedDocument(raw=raw, rdf_nquads=rdf_nquads, model=model, kind=k)
+    return UntpValidationRun(True, out, doc, None)
+
+
+def validate_untp_document(
+    data: Mapping[str, Any],
+    *,
+    kind: UntpArtefactKind | None = None,
+) -> UntpValidatedDocument:
+    """
+    Run JSON Schema validation (envelope and, for DCC credentials, ``credentialSubject``),
+    JSON-LD → RDF, and Pydantic parsing in order.
+
+    If ``kind`` is omitted, it is inferred from ``type`` via
+    :func:`detect_untp_artefact_kind`.
+    """
+    run = validate_untp_document_with_checks(data, kind=kind)
+    if run.success and run.document is not None:
+        return run.document
+    if run.raising is not None:
+        raise run.raising
+    raise UntpValidationError("UNTP validation failed")

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,44 +1,75 @@
-from pydantic_settings import BaseSettings
-import os
+from __future__ import annotations
+
 import logging
+import os
 from logging import Logger
-from dotenv import load_dotenv
+
+from pydantic import Field, computed_field, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 basedir = os.path.abspath(os.path.dirname(__file__))
-load_dotenv(os.path.join(basedir, ".env"))
 
 
 class Settings(BaseSettings):
+    """
+    Configuration from environment and optional ``.env`` (same directory as this file).
+
+    String settings default to local-development placeholders so ``import app`` works
+    without a populated ``.env``. Override everything real deployments need.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=os.path.join(basedir, ".env"),
+        env_file_encoding="utf-8",
+        extra="ignore",
+        arbitrary_types_allowed=True,
+    )
+
     PROJECT_TITLE: str = "Orgbook Publisher"
     PROJECT_VERSION: str = "v0"
 
     LOG_LEVEL: int = logging.INFO
-    LOG_FORMAT: str = "%(asctime)s | %(levelname)-8s | %(module)s:%(funcName)s:%(lineno)d | %(message)s"
-    LOGGER: Logger = logging.getLogger(__name__)
-    logging.basicConfig(level=LOG_LEVEL, format=LOG_FORMAT)
+    LOG_FORMAT: str = (
+        "%(asctime)s | %(levelname)-8s | %(module)s:%(funcName)s:%(lineno)d | %(message)s"
+    )
+    LOGGER: Logger = Field(default_factory=lambda: logging.getLogger(__name__))
 
-    DOMAIN: str = os.getenv("DOMAIN")
+    DOMAIN: str = Field(default="http://localhost")
+    TRACTION_API_URL: str = Field(default="http://localhost")
+    TRACTION_API_KEY: str = Field(default="dev-local")
+    TRACTION_TENANT_ID: str = Field(default="dev-local")
 
-    TRACTION_API_URL: str = os.getenv("TRACTION_API_URL")
-    TRACTION_API_KEY: str = os.getenv("TRACTION_API_KEY")
-    TRACTION_TENANT_ID: str = os.getenv("TRACTION_TENANT_ID")
+    ORGBOOK_URL: str = Field(default="http://localhost")
+    ORGBOOK_SYNC: bool = Field(default=True)
 
-    ORGBOOK_URL: str = os.getenv("ORGBOOK_URL")
-    ORGBOOK_API_URL: str = f"{ORGBOOK_URL}/api/v4"
+    DID_WEB_SERVER_URL: str = Field(default="http://localhost")
+    PUBLISHER_MULTIKEY: str = Field(default="dev-local")
+    ISSUER_REGISTRY_URL: str = Field(default="http://localhost")
 
-    DID_WEB_SERVER_URL: str = os.getenv("DID_WEB_SERVER_URL")
-    PUBLISHER_MULTIKEY: str = os.getenv("PUBLISHER_MULTIKEY")
-
-    ISSUER_REGISTRY_URL: str = os.getenv("ISSUER_REGISTRY_URL")
-
-    SECRET_KEY: str = TRACTION_API_KEY
-    JWT_SECRET: str = TRACTION_API_KEY
+    SECRET_KEY: str = Field(default="dev-local")
+    JWT_SECRET: str = Field(default="dev-local")
     JWT_ALGORITHM: str = "HS256"
 
-    MONGO_HOST: str = os.getenv("MONGO_HOST")
-    MONGO_PORT: str = os.getenv("MONGO_PORT")
-    MONGO_USER: str = os.getenv("MONGO_USER")
-    MONGO_PASSWORD: str = os.getenv("MONGO_PASSWORD")
-    MONGO_DB: str = os.getenv("MONGO_DB")
+    MONGO_HOST: str = Field(default="localhost")
+    MONGO_PORT: str = Field(default="27017")
+    MONGO_USER: str = Field(default="dev")
+    MONGO_PASSWORD: str = Field(default="dev")
+    MONGO_DB: str = Field(default="dev")
+
+    @computed_field
+    @property
+    def ORGBOOK_API_URL(self) -> str:
+        return f"{self.ORGBOOK_URL}/api/v4"
+
+    @computed_field
+    @property
+    def ORGBOOK_VC_SERVICE(self) -> str:
+        return f"{self.ORGBOOK_URL}/api/vc"
+
+    @model_validator(mode="after")
+    def _configure_logging(self) -> Settings:
+        logging.basicConfig(level=self.LOG_LEVEL, format=self.LOG_FORMAT)
+        return self
+
 
 settings = Settings()


### PR DESCRIPTION
## Summary

- Adds the DCC validation engine on top of bundled artefact infrastructure from PR A.
- Implements validation orchestration across JSON Schema, JSON-LD (offline context resolution), and Pydantic parsing.
- Wires supporting config/plugin/manual-model changes needed for validator behavior.

## Why this PR

- Keeps core validator behavior review separate from generated model churn and test-fixture additions.
- Focuses this step on executable validation logic and integration points.

## Included commit

- `256bd10` feat(backend): add DCC validator engine and model mapping

## Base / Head

- Base: `feature/untp-validator-dcc-a`
- Head: `feature/untp-validator-dcc-b`

## Files in scope

- `backend/app/validators/__init__.py`
- `backend/app/validators/untp.py`
- `backend/app/models/untp_manual.py`
- `backend/config.py`
- `backend/app/plugins/untp.py`
